### PR TITLE
Disable the polyfill when the method is available in ember-source

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Polyfills the RouterService#refresh method as described in [RFC 631](https://emb
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v3.4 or above
+* Ember.js v3.4 or above. The polyfill is disabled in Ember 4.1 and above.
 * Ember CLI v3.4 or above
 * Embroider safe and optimized
 * Node.js v12 or above

--- a/addon/initializers/setup-router-service-refresh-polyfill.js
+++ b/addon/initializers/setup-router-service-refresh-polyfill.js
@@ -1,45 +1,53 @@
 /* eslint-disable ember/no-private-routing-service */
 import { assert } from '@ember/debug';
 import { getOwner } from '@ember/application';
+import { dependencySatisfies, macroCondition } from '@embroider/macros';
+
+export const SHOULD_POLYFILL_ROUTER_SERVICE_REFRESH = !dependencySatisfies(
+  'ember-source',
+  '^4.1.0-beta.1' // https://github.com/emberjs/ember.js/blob/master/CHANGELOG.md#v410-beta1-november-19-2021
+);
 
 export function initialize(application) {
-  const RouterService = application.resolveRegistration('service:router');
+  if (macroCondition(SHOULD_POLYFILL_ROUTER_SERVICE_REFRESH)) {
+    const RouterService = application.resolveRegistration('service:router');
 
-  RouterService.reopen({
-    /**
-     * Refreshes all currently active routes, doing a full transition.
-     * If a routeName is provided and refers to a currently active route,
-     * it will refresh only that route and its descendents.
-     * Returns a promise that will be resolved once the refresh is complete.
-     * All resetController, beforeModel, model, afterModel, redirect, and setupController
-     * hooks will be called again. You will get new data from the model hook.
-     *
-     * @method refresh
-     * @param {String} [routeName] the route to refresh (along with all child routes)
-     * @return Transition
-     * @public
-     */
-    refresh(routeName) {
-      if (!routeName) {
-        return this._router._routerMicrolib.refresh();
-      }
+    RouterService.reopen({
+      /**
+       * Refreshes all currently active routes, doing a full transition.
+       * If a routeName is provided and refers to a currently active route,
+       * it will refresh only that route and its descendents.
+       * Returns a promise that will be resolved once the refresh is complete.
+       * All resetController, beforeModel, model, afterModel, redirect, and setupController
+       * hooks will be called again. You will get new data from the model hook.
+       *
+       * @method refresh
+       * @param {String} [routeName] the route to refresh (along with all child routes)
+       * @return Transition
+       * @public
+       */
+      refresh(routeName) {
+        if (!routeName) {
+          return this._router._routerMicrolib.refresh();
+        }
 
-      assert(
-        `The route "${routeName}" was not found`,
-        this._router.hasRoute(routeName)
-      );
+        assert(
+          `The route "${routeName}" was not found`,
+          this._router.hasRoute(routeName)
+        );
 
-      assert(
-        `The route "${routeName}" is currently not active`,
-        this.isActive(routeName)
-      );
+        assert(
+          `The route "${routeName}" is currently not active`,
+          this.isActive(routeName)
+        );
 
-      let owner = getOwner(this);
-      let pivotRoute = owner.lookup(`route:${routeName}`);
+        let owner = getOwner(this);
+        let pivotRoute = owner.lookup(`route:${routeName}`);
 
-      return this._router._routerMicrolib.refresh(pivotRoute);
-    },
-  });
+        return this._router._routerMicrolib.refresh(pivotRoute);
+      },
+    });
+  }
 }
 
 export default {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
+    "@embroider/macros": "^0.47.2",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-htmlbars": "^6.0.0"
   },

--- a/tests/acceptance/router-service-refresh-test.js
+++ b/tests/acceptance/router-service-refresh-test.js
@@ -3,98 +3,108 @@
 import Route from '@ember/routing/route';
 import { visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-import { module, test } from 'qunit';
+import { module } from 'qunit';
+import { testIfPolyfilled } from '../helpers/should-test-polyfill';
 
 module('Acceptance | RouterService | refresh', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('it can be used to re-run the model hooks of active routes', async function (assert) {
-    const routerService = this.owner.lookup('service:router');
+  testIfPolyfilled(
+    'it can be used to re-run the model hooks of active routes',
+    async function (assert) {
+      const routerService = this.owner.lookup('service:router');
 
-    let parentCounter = 0;
-    this.owner.register(
-      'route:parent',
-      Route.extend({
-        model() {
-          ++parentCounter;
-        },
-      })
-    );
+      let parentCounter = 0;
+      this.owner.register(
+        'route:parent',
+        Route.extend({
+          model() {
+            ++parentCounter;
+          },
+        })
+      );
 
-    let childCounter = 0;
-    this.owner.register(
-      'route:parent.child',
-      Route.extend({
-        model() {
-          ++childCounter;
-        },
-      })
-    );
+      let childCounter = 0;
+      this.owner.register(
+        'route:parent.child',
+        Route.extend({
+          model() {
+            ++childCounter;
+          },
+        })
+      );
 
-    let sisterCounter = 0;
-    this.owner.register(
-      'route:parent.sister',
-      Route.extend({
-        model() {
-          ++sisterCounter;
-        },
-      })
-    );
+      let sisterCounter = 0;
+      this.owner.register(
+        'route:parent.sister',
+        Route.extend({
+          model() {
+            ++sisterCounter;
+          },
+        })
+      );
 
-    await visit('/');
-    assert.strictEqual(parentCounter, 1);
-    assert.strictEqual(childCounter, 0);
-    assert.strictEqual(sisterCounter, 0);
+      await visit('/');
+      assert.strictEqual(parentCounter, 1);
+      assert.strictEqual(childCounter, 0);
+      assert.strictEqual(sisterCounter, 0);
 
-    await routerService.refresh();
-    assert.strictEqual(parentCounter, 2);
-    assert.strictEqual(childCounter, 0);
-    assert.strictEqual(sisterCounter, 0);
+      await routerService.refresh();
+      assert.strictEqual(parentCounter, 2);
+      assert.strictEqual(childCounter, 0);
+      assert.strictEqual(sisterCounter, 0);
 
-    await routerService.refresh('application');
-    assert.strictEqual(parentCounter, 3);
-    assert.strictEqual(childCounter, 0);
-    assert.strictEqual(sisterCounter, 0);
+      await routerService.refresh('application');
+      assert.strictEqual(parentCounter, 3);
+      assert.strictEqual(childCounter, 0);
+      assert.strictEqual(sisterCounter, 0);
 
-    await routerService.transitionTo('parent.child');
-    assert.strictEqual(parentCounter, 3);
-    assert.strictEqual(childCounter, 1);
-    assert.strictEqual(sisterCounter, 0);
+      await routerService.transitionTo('parent.child');
+      assert.strictEqual(parentCounter, 3);
+      assert.strictEqual(childCounter, 1);
+      assert.strictEqual(sisterCounter, 0);
 
-    await routerService.refresh('parent.child');
-    assert.strictEqual(parentCounter, 3);
-    assert.strictEqual(childCounter, 2);
-    assert.strictEqual(sisterCounter, 0);
+      await routerService.refresh('parent.child');
+      assert.strictEqual(parentCounter, 3);
+      assert.strictEqual(childCounter, 2);
+      assert.strictEqual(sisterCounter, 0);
 
-    await routerService.refresh('parent');
-    assert.strictEqual(parentCounter, 4);
-    assert.strictEqual(childCounter, 3);
-    assert.strictEqual(sisterCounter, 0);
+      await routerService.refresh('parent');
+      assert.strictEqual(parentCounter, 4);
+      assert.strictEqual(childCounter, 3);
+      assert.strictEqual(sisterCounter, 0);
 
-    await routerService.transitionTo('parent.sister');
-    assert.strictEqual(parentCounter, 4);
-    assert.strictEqual(childCounter, 3);
-    assert.strictEqual(sisterCounter, 1);
+      await routerService.transitionTo('parent.sister');
+      assert.strictEqual(parentCounter, 4);
+      assert.strictEqual(childCounter, 3);
+      assert.strictEqual(sisterCounter, 1);
 
-    await routerService.refresh();
-    assert.strictEqual(parentCounter, 5);
-    assert.strictEqual(childCounter, 3);
-    assert.strictEqual(sisterCounter, 2);
-  });
+      await routerService.refresh();
+      assert.strictEqual(parentCounter, 5);
+      assert.strictEqual(childCounter, 3);
+      assert.strictEqual(sisterCounter, 2);
+    }
+  );
 
-  test('it verifies that the provided route exists', async function (assert) {
-    const routerService = this.owner.lookup('service:router');
+  testIfPolyfilled(
+    'it verifies that the provided route exists',
+    async function (assert) {
+      const routerService = this.owner.lookup('service:router');
 
-    assert.throws(() => {
-      routerService.refresh('this-route-does-not-exist');
-    });
-  });
+      assert.throws(() => {
+        routerService.refresh('this-route-does-not-exist');
+      });
+    }
+  );
 
-  test('it verifies that the provided route is active', async function (assert) {
-    const routerService = this.owner.lookup('service:router');
+  testIfPolyfilled(
+    'it verifies that the provided route is active',
+    async function (assert) {
+      const routerService = this.owner.lookup('service:router');
 
-    assert.throws(() => {
-      routerService.refresh('this-route-does-not-exist');
-    });
-  });
+      assert.throws(() => {
+        routerService.refresh('this-route-does-not-exist');
+      });
+    }
+  );
 });

--- a/tests/helpers/should-test-polyfill.js
+++ b/tests/helpers/should-test-polyfill.js
@@ -1,0 +1,6 @@
+import { test, skip } from 'qunit';
+import { SHOULD_POLYFILL_ROUTER_SERVICE_REFRESH } from 'ember-router-service-refresh-polyfill/initializers/setup-router-service-refresh-polyfill';
+
+export const testIfPolyfilled = SHOULD_POLYFILL_ROUTER_SERVICE_REFRESH
+  ? test
+  : skip;

--- a/tests/unit/initializers/setup-router-service-refresh-polyfill-test.js
+++ b/tests/unit/initializers/setup-router-service-refresh-polyfill-test.js
@@ -2,9 +2,10 @@ import Application from '@ember/application';
 
 import config from 'dummy/config/environment';
 import { initialize } from 'dummy/initializers/setup-router-service-refresh-polyfill';
-import { module, test } from 'qunit';
+import { module } from 'qunit';
 import Resolver from 'ember-resolver';
 import { run } from '@ember/runloop';
+import { testIfPolyfilled } from '../../helpers/should-test-polyfill';
 
 module(
   'Unit | Initializer | setup-router-service-refresh-polyfill',
@@ -28,12 +29,15 @@ module(
       run(this.application, 'destroy');
     });
 
-    test('it adds the polyfilled refresh method to the RouterService', async function (assert) {
-      await this.application.boot();
-      const applicationInstance = this.application.buildInstance();
-      const routerService = applicationInstance.lookup('service:router');
+    testIfPolyfilled(
+      'it adds the polyfilled refresh method to the RouterService',
+      async function (assert) {
+        await this.application.boot();
+        const applicationInstance = this.application.buildInstance();
+        const routerService = applicationInstance.lookup('service:router');
 
-      assert.strictEqual(typeof routerService.refresh, 'function');
-    });
+        assert.strictEqual(typeof routerService.refresh, 'function');
+      }
+    );
   }
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,6 +1082,32 @@
     resolve "^1.8.1"
     semver "^7.3.2"
 
+"@embroider/macros@^0.47.2":
+  version "0.47.2"
+  resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-0.47.2.tgz#23cbe92cac3c24747f054e1eea2a22538bf7ebd0"
+  integrity sha512-ViNWluJCeM5OPlM3rs8kdOz3RV5rpfXX5D2rDnc/q86xRS0xf4NFEjYRV7W6fBcD0b3v5jSHDTwrjq9Kee4rHg==
+  dependencies:
+    "@embroider/shared-internals" "0.47.2"
+    assert-never "^1.2.1"
+    ember-cli-babel "^7.26.6"
+    find-up "^5.0.0"
+    lodash "^4.17.21"
+    resolve "^1.20.0"
+    semver "^7.3.2"
+
+"@embroider/shared-internals@0.47.2":
+  version "0.47.2"
+  resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-0.47.2.tgz#24e9fa0dd9c529d5c996ee1325729ea08d1fa19f"
+  integrity sha512-SxdZYjAE0fiM5zGDz+12euWIsQZ1tsfR1k+NKmiWMyLhA5T3pNgbR2/Djvx/cVIxOtEavGGSllYbzRKBtV4xMg==
+  dependencies:
+    babel-import-util "^0.2.0"
+    ember-rfc176-data "^0.3.17"
+    fs-extra "^9.1.0"
+    lodash "^4.17.21"
+    resolve-package-path "^4.0.1"
+    semver "^7.3.5"
+    typescript-memoize "^1.0.1"
+
 "@embroider/shared-internals@^0.40.0":
   version "0.40.0"
   resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-0.40.0.tgz#2f768c60f4f35ba5f9228f046f70324851e8bfe2"
@@ -2312,7 +2338,7 @@ asn1.js@^5.2.0:
     minimalistic-assert "^1.0.0"
     safer-buffer "^2.1.0"
 
-assert-never@^1.1.0:
+assert-never@^1.1.0, assert-never@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/assert-never/-/assert-never-1.2.1.tgz#11f0e363bf146205fb08193b5c7b90f4d1cf44fe"
   integrity sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==
@@ -10264,7 +10290,7 @@ resolve-package-path@^3.1.0:
     path-root "^0.1.1"
     resolve "^1.17.0"
 
-resolve-package-path@^4.0.0:
+resolve-package-path@^4.0.0, resolve-package-path@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/resolve-package-path/-/resolve-package-path-4.0.3.tgz#31dab6897236ea6613c72b83658d88898a9040aa"
   integrity sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==
@@ -11665,7 +11691,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript-memoize@^1.0.0-alpha.3:
+typescript-memoize@^1.0.0-alpha.3, typescript-memoize@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.1.0.tgz#4a8f512d06fc995167c703a3592219901db8bc79"
   integrity sha512-LQPKVXK8QrBBkL/zclE6YgSWn0I8ew5m0Lf+XL00IwMhlotqRLlzHV+BRrljVQIc+NohUAuQP7mg4HQwrx5Xbg==


### PR DESCRIPTION
This uses @embroider/macros to disable the polyfill when the addon runs in an Ember version that includes the refresh method already.

~~Draft status since the exact version isn't known yet, and it might be "better" to use the treeFor hooks and not return the initializer files at all. That's how other ember polyfills seem to do it.~~ It's released in [Ember 4.1.0-beta.1](https://github.com/emberjs/ember.js/blob/master/CHANGELOG.md#v410-beta1-november-19-2021) :tada:.

Closes #1 