### PR TITLE
Convert ember-cli-htmlbars to a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
   },
   "dependencies": {
     "@embroider/macros": "^1.0.0",
-    "ember-cli-babel": "^7.26.11",
-    "ember-cli-htmlbars": "^6.0.1"
+    "ember-cli-babel": "^7.26.11"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
@@ -45,6 +44,7 @@
     "ember-cli": "~3.28.4",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-inject-live-reload": "^2.1.0",
+    "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
     "ember-disable-prototype-extensions": "^1.1.3",


### PR DESCRIPTION
The addon doesn't provide any templates so it doesn't need to be shipped to consumers.